### PR TITLE
Import FQCNs

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -321,7 +321,9 @@ $config = (new PhpCsFixer\Config())
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// Import
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		"fully_qualified_strict_types" => true,
+		"fully_qualified_strict_types" => [
+			"import_symbols" => true,
+		],
 		"global_namespace_import" => [
 			"import_classes" => false,
 			"import_constants" => false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.1.4
+=====
+
+* (improvement) Make sure to always import FQCNs.
+
+
 1.1.3
 =====
 


### PR DESCRIPTION
`import_symbols` by default is set to `false`. If we want to make sure that we're always importing FQCNs, we need to enable it.

See https://cs.symfony.com/doc/rules/import/fully_qualified_strict_types.html#example-4

This is an important rule when used in combination with tools like Rector that are always using FQCNs for the code rewriting process.